### PR TITLE
Update rules to prevent comments we ignore and out of date suggestions

### DIFF
--- a/blazor.instructions.md
+++ b/blazor.instructions.md
@@ -6,7 +6,7 @@ applyTo: '**/*.razor, **/*.razor.cs, **/*.razor.css'
 # Blazor Instructions
 
 - Version: 1.1
-- Last reviewed: April 2026
+- Last reviewed: May 2026
 
 ## General Instructions
 - Never suggest changes to a file without first checking the current version of the file. The developer may have already implemented changes since it was last read. 

--- a/blazor.instructions.md
+++ b/blazor.instructions.md
@@ -5,8 +5,8 @@ applyTo: '**/*.razor, **/*.razor.cs, **/*.razor.css'
 
 # Blazor Instructions
 
-- Version: 1.0
-- Last reviewed: December 2025
+- Version: 1.1
+- Last reviewed: April 2026
 
 ## General Instructions
 - Never suggest changes to a file without first checking the current version of the file. The developer may have already implemented changes since it was last read. 

--- a/blazor.instructions.md
+++ b/blazor.instructions.md
@@ -8,6 +8,9 @@ applyTo: '**/*.razor, **/*.razor.cs, **/*.razor.css'
 - Version: 1.0
 - Last reviewed: December 2025
 
+## General Instructions
+- Never suggest changes to a file without first checking the current version of the file. The developer may have already implemented changes since it was last read. 
+
 ## Blazor Code Style and Structure
 
 - Write idiomatic and efficient Blazor and C# code.

--- a/blazor.instructions.md
+++ b/blazor.instructions.md
@@ -9,7 +9,7 @@ applyTo: '**/*.razor, **/*.razor.cs, **/*.razor.css'
 - Last reviewed: May 2026
 
 ## General Instructions
-- Never suggest changes to a file without first checking the current version of the file. The developer may have already implemented changes since it was last read. 
+- Never suggest changes to a file without first checking the current version of the file. The developer may have already implemented changes since it was last read.
 
 ## Blazor Code Style and Structure
 

--- a/csharp-rest-api.instructions.md
+++ b/csharp-rest-api.instructions.md
@@ -9,7 +9,7 @@ applyTo: '**/Controllers/*.cs, **/Endpoints/*.cs', '**/Services/*.cs, **/Reposit
 - Last reviewed: May 2026
 
 ## General Instructions
-- Never suggest changes to a file without first checking the current version of the file. The developer may have already implemented changes since it was last read. 
+- Never suggest changes to a file without first checking the current version of the file. The developer may have already implemented changes since it was last read.
 
 ## API Instructions
 

--- a/csharp-rest-api.instructions.md
+++ b/csharp-rest-api.instructions.md
@@ -8,6 +8,9 @@ applyTo: '**/Controllers/*.cs, **/Endpoints/*.cs', '**/Services/*.cs, **/Reposit
 - Version: 1.0
 - Last reviewed: December 2025
 
+## General Instructions
+- Never suggest changes to a file without first checking the current version of the file. The developer may have already implemented changes since it was last read. 
+
 ## API Instructions
 
 - For C# guidance follow the instructions in [C# Development](csharp.instructions.md)

--- a/csharp-rest-api.instructions.md
+++ b/csharp-rest-api.instructions.md
@@ -6,7 +6,7 @@ applyTo: '**/Controllers/*.cs, **/Endpoints/*.cs', '**/Services/*.cs, **/Reposit
 # ASP.NET REST API Development
 
 - Version: 1.1
-- Last reviewed: April 2026
+- Last reviewed: May 2026
 
 ## General Instructions
 - Never suggest changes to a file without first checking the current version of the file. The developer may have already implemented changes since it was last read. 

--- a/csharp-rest-api.instructions.md
+++ b/csharp-rest-api.instructions.md
@@ -5,8 +5,8 @@ applyTo: '**/Controllers/*.cs, **/Endpoints/*.cs', '**/Services/*.cs, **/Reposit
 
 # ASP.NET REST API Development
 
-- Version: 1.0
-- Last reviewed: December 2025
+- Version: 1.1
+- Last reviewed: April 2026
 
 ## General Instructions
 - Never suggest changes to a file without first checking the current version of the file. The developer may have already implemented changes since it was last read. 

--- a/csharp-unit-test.instructions.md
+++ b/csharp-unit-test.instructions.md
@@ -5,8 +5,8 @@ applyTo: 'Tests/**/*.cs'
 
 # C# Unit Testing Guidelines
 
-- Version 1.0
-- Last reviewed: December 2025
+- Version 1.1
+- Last reviewed: April 2026
 - 
 This document provides best practices and standards for writing, organizing, and maintaining unit tests in C# projects. It is intended to ensure high-quality, maintainable, and reliable tests that support robust software development.
 

--- a/csharp-unit-test.instructions.md
+++ b/csharp-unit-test.instructions.md
@@ -6,7 +6,7 @@ applyTo: 'Tests/**/*.cs'
 # C# Unit Testing Guidelines
 
 - Version 1.1
-- Last reviewed: April 2026
+- Last reviewed: May 2026
 - 
 This document provides best practices and standards for writing, organizing, and maintaining unit tests in C# projects. It is intended to ensure high-quality, maintainable, and reliable tests that support robust software development.
 

--- a/csharp-unit-test.instructions.md
+++ b/csharp-unit-test.instructions.md
@@ -20,6 +20,7 @@ This document provides best practices and standards for writing, organizing, and
 - Avoid duplicating test logic; use [Theory] and [MemberData] for parameterized tests.
 - Mock dependencies using NSubstitute and NSubstitute.Analyzers.CSharp.
 - Do not use real external resources (e.g., databases, file systems, network) in unit tests.
+- Never suggest changes to a file without first checking the current version of the file. The developer may have already implemented changes since it was last read. 
 
 ## Test Structure and Organization
 

--- a/csharp-unit-test.instructions.md
+++ b/csharp-unit-test.instructions.md
@@ -5,9 +5,9 @@ applyTo: 'Tests/**/*.cs'
 
 # C# Unit Testing Guidelines
 
-- Version 1.1
+- Version: 1.1
 - Last reviewed: May 2026
-- 
+
 This document provides best practices and standards for writing, organizing, and maintaining unit tests in C# projects. It is intended to ensure high-quality, maintainable, and reliable tests that support robust software development.
 
 ## General Instructions
@@ -20,7 +20,7 @@ This document provides best practices and standards for writing, organizing, and
 - Avoid duplicating test logic; use [Theory] and [MemberData] for parameterized tests.
 - Mock dependencies using NSubstitute and NSubstitute.Analyzers.CSharp.
 - Do not use real external resources (e.g., databases, file systems, network) in unit tests.
-- Never suggest changes to a file without first checking the current version of the file. The developer may have already implemented changes since it was last read. 
+- Never suggest changes to a file without first checking the current version of the file. The developer may have already implemented changes since it was last read.
 
 ## Test Structure and Organization
 

--- a/csharp.instructions.md
+++ b/csharp.instructions.md
@@ -5,8 +5,8 @@ applyTo: '**/*.cs'
 
 # C# Development
 
-- Version: 1.0
-- Last reviewed: December 2025
+- Version: 1.1
+- Last reviewed: April 2026
 
 ## C# Instructions
 - Always use the latest version C# in use within the project but highlight if an upgrade is available.

--- a/csharp.instructions.md
+++ b/csharp.instructions.md
@@ -11,6 +11,7 @@ applyTo: '**/*.cs'
 ## C# Instructions
 - Always use the latest version C# in use within the project but highlight if an upgrade is available.
 - Always highlight if upgrading to a newer version of C# would enable better coding patterns or practices.
+- Never comment on files using Microsoft.EntityFrameworkCore.Migrations as these are auto-generated and should not be modified manually. If you find an issue comment on the DbContext model that generated the issue instead.
 
 ## General Instructions
 - Make only high confidence suggestions when reviewing code changes.

--- a/csharp.instructions.md
+++ b/csharp.instructions.md
@@ -18,7 +18,7 @@ applyTo: '**/*.cs'
 - Write code with good maintainability practices, including comments on why certain design decisions were made.
 - Handle edge cases and write clear exception handling.
 - For libraries or external dependencies, mention their usage and purpose in comments.
-- Never suggest changes to a file without first checking the current version of the file. The developer may have already implemented changes since it was last read. 
+- Never suggest changes to a file without first checking the current version of the file. The developer may have already implemented changes since it was last read.
 
 ## Naming Conventions
 

--- a/csharp.instructions.md
+++ b/csharp.instructions.md
@@ -6,7 +6,7 @@ applyTo: '**/*.cs'
 # C# Development
 
 - Version: 1.1
-- Last reviewed: April 2026
+- Last reviewed: May 2026
 
 ## C# Instructions
 - Always use the latest version C# in use within the project but highlight if an upgrade is available.

--- a/csharp.instructions.md
+++ b/csharp.instructions.md
@@ -17,6 +17,7 @@ applyTo: '**/*.cs'
 - Write code with good maintainability practices, including comments on why certain design decisions were made.
 - Handle edge cases and write clear exception handling.
 - For libraries or external dependencies, mention their usage and purpose in comments.
+- Never suggest changes to a file without first checking the current version of the file. The developer may have already implemented changes since it was last read. 
 
 ## Naming Conventions
 


### PR DESCRIPTION
We are finding that Co-pilot sometimes suggests changes that have already been applied to files locally. These changes should explicitly tell Co-pilot that it should not tell you to change something without actually double checking the target file to see if the suggestion has already been applied. 

This is essential as many developers may choose to apply suggestions in different ways to how Co-pilot is expecting so we want to allow for this but not junk up a Co-pilot chat with previous suggestions that may already be implemented. 

I've also added an extra line to discourage the automatic reviews commenting on Migration files. These are automatically generated so if an issue is detected the AI should assess whether the source models still contain the relationships that led to the issue it is seeing in the migration. If it is still present the comment should be associated with the Entity classes/records rather than the migration file itself. 
